### PR TITLE
Add Jenkinsfile for Pipeline for caasp-services

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,5 @@
+def targetBranch = env.getEnvironment().get('CHANGE_TARGET', env.BRANCH_NAME)
+
+library "kubic-jenkins-library@${targetBranch}"
+
+coreKubicProjectCi()


### PR DESCRIPTION
Add a new Jenkinsfile which defines the pipeline for the
caasp-services repository. Initially this pipeline is identical to the
pipelines of the other CaaSP projects.