### PR TITLE
Adds Clair and supporting Postgres DB to Portus configuration

### DIFF
--- a/docs/portus/insecure/clair/clair.cm.yml
+++ b/docs/portus/insecure/clair/clair.cm.yml
@@ -1,0 +1,90 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: portus-clair-config 
+data:
+  config: |
+    clair:
+      database:
+        # Database driver
+        type: pgsql
+        options:
+          # PostgreSQL Connection string
+          # https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING
+          # This should be done using secrets or Vault, but for now this will also work
+          source: "postgres://clair:password@postgres:5432/clair?sslmode=disable"
+
+          # Number of elements kept in the cache
+          # Values unlikely to change (e.g. namespaces) are cached in order to save prevent needless roundtrips to the database.
+          cachesize: 16384
+
+          # 32-bit URL-safe base64 key used to encrypt pagination tokens
+          # If one is not provided, it will be generated.
+          # Multiple clair instances in the same cluster need the same value.
+          paginationkey: "XxoPtCUzrUv4JV5dS+yQ+MdW7yLEJnRMwigVY/bpgtQ="
+      api:
+        # v3 grpc/RESTful API server address
+        addr: "0.0.0.0:6060"
+
+        # Health server address
+        # This is an unencrypted endpoint useful for load balancers to check to healthiness of the clair server.
+        healthaddr: "0.0.0.0:6061"
+
+        # Deadline before an API request will respond with a 503
+        timeout: 900s
+
+        # Optional PKI configuration
+        # If you want to easily generate client certificates and CAs, try the following projects:
+        # https://github.com/coreos/etcd-ca
+        # https://github.com/cloudflare/cfssl
+        servername:
+        cafile:
+        keyfile:
+        certfile:
+
+      worker:
+        namespace_detectors:
+        - os-release
+        - lsb-release
+        - apt-sources
+        - alpine-release
+        - redhat-release
+
+        feature_listers:
+        - apk
+        - dpkg
+        - rpm
+
+      updater:
+        # Frequency the database will be updated with vulnerabilities from the default data sources
+        # The value 0 disables the updater entirely.
+        interval: 6h 
+        enabledupdaters:
+        - debian
+        - ubuntu
+        - rhel
+        - oracle
+        - alpine
+
+      notifier:
+        # Number of attempts before the notification is marked as failed to be sent
+        attempts: 3
+
+        # Duration before a failed notification is retried
+        renotifyinterval: 2h
+
+        http:
+          # Optional endpoint that will receive notifications via POST requests
+          endpoint: 
+
+          # Optional PKI configuration
+          # If you want to easily generate client certificates and CAs, try the following projects:
+          # https://github.com/cloudflare/cfssl
+          # https://github.com/coreos/etcd-ca
+          servername:
+          cafile:
+          keyfile:
+          certfile:
+
+          # Optional HTTP Proxy: must be a valid URL (including the scheme).
+          proxy:

--- a/docs/portus/insecure/clair/clair.deploy.yml
+++ b/docs/portus/insecure/clair/clair.deploy.yml
@@ -1,0 +1,38 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: portus-clair-deployment 
+  labels:
+    name: portus-clair-deployment
+spec:
+  replicas: 1 
+  selector: 
+    matchLabels:
+      name: portus-clair-apps
+  template:
+    metadata:
+      labels:
+        name: portus-clair-apps 
+    spec:
+      containers:
+      - name: portus-clair 
+        image: quay.io/coreos/clair:latest
+        imagePullPolicy: IfNotPresent
+        args: ["--insecure-tls"] 
+        ports:
+        - name: clair-api
+          containerPort: 6060
+          protocol: TCP
+        - name: clair-health
+          containerPort: 6061
+          protocol: TCP
+        volumeMounts:
+        - name: config
+          mountPath: /etc/clair
+      volumes:
+      - name: config
+        configMap:
+          name: portus-clair-config  
+          items:
+          - key: config
+            path: config.yaml

--- a/docs/portus/insecure/clair/clair.svc.yml
+++ b/docs/portus/insecure/clair/clair.svc.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: clair 
+spec:
+  ports:
+    - name: api 
+      port: 6060 
+    - name: health
+      port: 6061 
+  selector:
+    name: portus-clair-apps

--- a/docs/portus/insecure/cleanup
+++ b/docs/portus/insecure/cleanup
@@ -1,4 +1,15 @@
 #! /bin/bash
+
+kubectl delete cm portus-postgres-config
+kubectl delete deploy portus-postgres-deployment 
+kubectl delete svc postgres 
+echo "Clair Postgres database removed"
+
+kubectl delete cm portus-clair-config
+kubectl delete deploy portus-clair-deployment 
+kubectl delete svc clair 
+echo "Clair removed"
+
 kubectl delete cm portus-db-config 
 kubectl delete deploy portus-db-deployment 
 kubectl delete svc db 

--- a/docs/portus/insecure/portus/portus.cm.yml
+++ b/docs/portus/insecure/portus/portus.cm.yml
@@ -13,6 +13,7 @@ data:
   PORTUS_CHECK_SSL_USAGE_ENABLED: "false"
   RAILS_SERVE_STATIC_FILES: "true"
   PORTUS_INIT_COMMAND: "bin/crono"
+  PORTUS_SECURITY_CLAIR_SERVER: "clair:6060"
  
   key: |
     -----BEGIN RSA PRIVATE KEY-----

--- a/docs/portus/insecure/portus/portus.deploy.yml
+++ b/docs/portus/insecure/portus/portus.deploy.yml
@@ -65,6 +65,11 @@ spec:
               configMapKeyRef:
                name: portus-config
                key: RAILS_SERVE_STATIC_FILES
+          - name: PORTUS_SECURITY_CLAIR_SERVER
+            valueFrom:
+              configMapKeyRef:
+               name: portus-config
+               key: PORTUS_SECURITY_CLAIR_SERVER
         volumeMounts:
         - name: secrets
           mountPath: /certificates

--- a/docs/portus/insecure/postgres/postgres.cm.yml
+++ b/docs/portus/insecure/postgres/postgres.cm.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: portus-postgres-config 
+data:
+  POSTGRES_DATABASE: "postgres"
+  POSTGRES_USER: "clair"
+  POSTGRES_PASSWORD: "password"

--- a/docs/portus/insecure/postgres/postgres.deploy.yml
+++ b/docs/portus/insecure/postgres/postgres.deploy.yml
@@ -1,0 +1,38 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: portus-postgres-deployment 
+  labels:
+    name: portus-postgres-deployment
+spec:
+  replicas: 1 
+  selector: 
+    matchLabels:
+      name: portus-postgres-apps
+  template:
+    metadata:
+      labels:
+        name: portus-postgres-apps 
+    spec:
+      containers:
+      - name: portus-postgres-apps 
+        image: library/postgres:10.0
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 5432
+        env:
+          - name: POSTGRES_DATABASE
+            valueFrom:
+              configMapKeyRef:
+               name: portus-postgres-config
+               key: POSTGRES_DATABASE
+          - name: POSTGRES_USER
+            valueFrom:
+              configMapKeyRef:
+                name: portus-postgres-config
+                key: POSTGRES_USER
+          - name: POSTGRES_PASSWORD
+            valueFrom:
+              configMapKeyRef:
+               name: portus-postgres-config
+               key: POSTGRES_PASSWORD

--- a/docs/portus/insecure/postgres/postgres.svc.yml
+++ b/docs/portus/insecure/postgres/postgres.svc.yml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres 
+spec:
+  ports:
+    - port: 5432 
+  selector:
+    name: portus-postgres-apps

--- a/docs/portus/insecure/start
+++ b/docs/portus/insecure/start
@@ -1,4 +1,15 @@
 #! /bin/bash
+
+kubectl apply -f postgres/postgres.cm.yml
+kubectl apply -f postgres/postgres.deploy.yml
+kubectl apply -f postgres/postgres.svc.yml
+echo "Clair Postgres database added"
+
+kubectl apply -f clair/clair.cm.yml
+kubectl apply -f clair/clair.deploy.yml
+kubectl apply -f clair/clair.svc.yml
+echo "Clair added"
+
 kubectl apply -f db/db.cm.yml
 kubectl apply -f db/db.deploy.yml
 kubectl apply -f db/db.svc.yml


### PR DESCRIPTION
Configuration for Clair within the Portus deployment.

Clair is used to scan uploaded images for security vulnerabilities. It is setup by default to sync security vulnerabilities from a number of different sources- see the Updaters in the Clair config file.

This setup is not using SSL, but it should be easy to add SSL support to the Clair config file once we update the Portus configuration to use SSL.  