### PR TITLE
Removes nodeport from registry in Portus Kubernetes configuration

### DIFF
--- a/docs/portus/insecure/nginx/nginx.cm.yml
+++ b/docs/portus/insecure/nginx/nginx.cm.yml
@@ -42,9 +42,9 @@ data:
         server portus:3000 max_fails=3 fail_timeout=15s;
       }
     
-      upstream registry {
+      upstream registry:5000 {
         least_conn;
-        server registry:30521 max_fails=3 fail_timeout=15s;
+        server registry:5000 max_fails=3 fail_timeout=15s;
       }
     
       server {
@@ -103,7 +103,7 @@ data:
           ## See the map directive above where this variable is defined.
           add_header 'Docker-Distribution-Api-Version' $docker_distribution_api_version always;
     
-          proxy_pass http://registry;
+          proxy_pass http://registry:5000;
           proxy_set_header X-Real-IP $remote_addr; # pass on real client's IP
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           proxy_set_header X-Forwarded-Proto $scheme;

--- a/docs/portus/insecure/registry/registry.cm.yml
+++ b/docs/portus/insecure/registry/registry.cm.yml
@@ -4,7 +4,7 @@ metadata:
   name: portus-registry-config
 data:
   REGISTRY_AUTH_TOKEN_REALM: "http://nginx:32123/v2/token"
-  REGISTRY_AUTH_TOKEN_SERVICE: "registry:30521"
+  REGISTRY_AUTH_TOKEN_SERVICE: "registry:5000"
   REGISTRY_AUTH_TOKEN_ISSUER: "nginx" 
   REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE: "secrets/portus.crt"
 
@@ -23,7 +23,7 @@ data:
       delete:
         enabled: true
     http:
-      addr: 0.0.0.0:30521
+      addr: 0.0.0.0:5000
       debug:
         addr: 0.0.0.0:5001
 

--- a/docs/portus/insecure/registry/registry.deploy.yml
+++ b/docs/portus/insecure/registry/registry.deploy.yml
@@ -19,7 +19,7 @@ spec:
         image: library/registry:2.6
         imagePullPolicy: IfNotPresent
         ports:
-        - containerPort: 30521
+        - containerPort: 5000
         - containerPort: 5001
         env:
           - name: REGISTRY_AUTH_TOKEN_REALM

--- a/docs/portus/insecure/registry/registry.svc.yml
+++ b/docs/portus/insecure/registry/registry.svc.yml
@@ -3,11 +3,9 @@ kind: Service
 metadata:
   name: registry
 spec:
-  type: NodePort
   ports:
     - name: repo
-      port: 30521
-      nodePort: 30521
+      port: 5000
     - name: debug
       port: 5001
   selector:


### PR DESCRIPTION
Nginx is the only entry point we need, so this removes the registry nodeport.