### PR TITLE
Adds persistent storage to Portus Helm chart

### DIFF
--- a/contrib/helm-charts/Portus/templates/registry-configmap.yaml
+++ b/contrib/helm-charts/Portus/templates/registry-configmap.yaml
@@ -24,7 +24,7 @@ data:
     version: 0.1
     storage:
       filesystem:
-        rootdirectory: /var/lib/registry
+        rootdirectory: {{ .Values.registry.mountPath }}
       delete:
         enabled: true
     http:

--- a/contrib/helm-charts/Portus/templates/registry-deployment.yaml
+++ b/contrib/helm-charts/Portus/templates/registry-deployment.yaml
@@ -71,6 +71,8 @@ spec:
             - name: config
               mountPath: /etc/docker/registry
               readOnly: true
+            - name: storage
+              mountPath: {{ .Values.registry.mountPath }}
       volumes:
         - name: certvol
           secret:
@@ -86,3 +88,10 @@ spec:
             items:
               - key: config
                 path: config.yml
+        - name: storage
+          {{- if .Values.registry.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: "{{ .Release.Name }}-{{ .Values.registry.name }}"
+          {{- else }}
+          emptyDir: {}
+          {{- end }}

--- a/contrib/helm-charts/Portus/templates/registry-persistent-volume-claim.yaml
+++ b/contrib/helm-charts/Portus/templates/registry-persistent-volume-claim.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.registry.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ .Release.Name }}-{{ .Values.registry.name }}"
+  labels:
+    storage: "{{ .Release.Name }}-{{ .Values.registry.name }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  accessModes:
+    - {{ .Values.registry.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.registry.persistence.capacity }}
+{{- end }}

--- a/contrib/helm-charts/Portus/values.yaml
+++ b/contrib/helm-charts/Portus/values.yaml
@@ -41,6 +41,11 @@ crono:
 ##
 registry:
   name: "registry"
+  mountPath: "/storage"
+  persistence:
+    enabled: true
+    accessMode: "ReadWriteOnce"
+    capacity: "10Gi"
   image: 
     repository: "library/registry"
     tag: "latest" 
@@ -48,11 +53,11 @@ registry:
   replicas: 1
   port: "5000"
   debugPort: "5001"
-    
+
 ## Default values for Nginx. 
 ##
 nginx:
-  name: "portus-nginx"
+  name: "nginx"
   image: 
     repository: "library/nginx"
     tag: "alpine"


### PR DESCRIPTION
Adds a persistence option to the registry deployment in the Portus helm chart, and a persistent volume claim that is set up if `.Values.registry.persistence.enabled` is set to true, which it is by default.

I tested this with a pool I created in our Cepth deployment by creating a default storage class to reference the Cepth pool, and installing this chart with the persistence enabled, which successfully bound to my default storage.