### PR TITLE
Adds Portus chart support for existing mariadb instance

### DIFF
--- a/contrib/helm-charts/Portus/requirements.yaml
+++ b/contrib/helm-charts/Portus/requirements.yaml
@@ -2,3 +2,4 @@ dependencies:
   - name: mariadb 
     version: 2.0.1 
     repository: https://kubernetes-charts.storage.googleapis.com/
+    condition: mariadb.enabled

--- a/contrib/helm-charts/Portus/templates/crono-deployment.yaml
+++ b/contrib/helm-charts/Portus/templates/crono-deployment.yaml
@@ -49,6 +49,11 @@ spec:
                 configMapKeyRef: 
                   name: "{{ .Release.Name }}-{{ .Values.portus.name }}"  
                   key: PORTUS_PRODUCTION_DATABASE
+            - name: PORTUS_PRODUCTION_USERNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: "{{ .Release.Name }}-{{ .Values.portus.name }}"
+                  key: PORTUS_PRODUCTION_USERNAME
             - name: PORTUS_PRODUCTION_PASSWORD
               valueFrom:
                 secretKeyRef: 

--- a/contrib/helm-charts/Portus/templates/crono-deployment.yaml
+++ b/contrib/helm-charts/Portus/templates/crono-deployment.yaml
@@ -49,11 +49,6 @@ spec:
                 configMapKeyRef: 
                   name: "{{ .Release.Name }}-{{ .Values.portus.name }}"  
                   key: PORTUS_PRODUCTION_DATABASE
-            - name: PORTUS_PRODUCTION_USERNAME
-              valueFrom:
-                configMapKeyRef: 
-                  name: "{{ .Release.Name }}-{{ .Values.portus.name }}"  
-                  key: PORTUS_PRODUCTION_USERNAME
             - name: PORTUS_PRODUCTION_PASSWORD
               valueFrom:
                 secretKeyRef: 

--- a/contrib/helm-charts/Portus/templates/portus-configmap.yaml
+++ b/contrib/helm-charts/Portus/templates/portus-configmap.yaml
@@ -9,9 +9,12 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   PORTUS_MACHINE_FQDN_VALUE: {{ .Values.portus.fqdnValue | quote }}
-  PORTUS_PRODUCTION_HOST: "{{ .Release.Name }}-{{ .Values.portus.productionHost }}"
-  PORTUS_PRODUCTION_DATABASE: {{ .Values.portus.productionDatabase | quote }}
-  PORTUS_PRODUCTION_USERNAME: {{ .Values.portus.productionUsername | quote }}
+  {{- if .Values.mariadb.enabled }}
+  PORTUS_PRODUCTION_HOST: "{{ .Release.Name }}-mariadb"
+  {{- else }}
+  PORTUS_PRODUCTION_HOST: {{ .Values.mariadb.name | quote }}
+  {{- end }}
+  PORTUS_PRODUCTION_DATABASE: {{ .Values.mariadb.mariadbDatabase | quote }}
   PORTUS_KEY_PATH: "/certificates/portus.key"
   PORTUS_CERT_PATH: "/certificates/portus.crt"
   PORTUS_CHECK_SSL_USAGE_ENABLED: "true" 

--- a/contrib/helm-charts/Portus/templates/portus-configmap.yaml
+++ b/contrib/helm-charts/Portus/templates/portus-configmap.yaml
@@ -12,9 +12,10 @@ data:
   {{- if .Values.mariadb.enabled }}
   PORTUS_PRODUCTION_HOST: "{{ .Release.Name }}-mariadb"
   {{- else }}
-  PORTUS_PRODUCTION_HOST: {{ .Values.mariadb.name | quote }}
+  PORTUS_PRODUCTION_HOST: {{ .Values.portus.productionHost | quote }}
   {{- end }}
-  PORTUS_PRODUCTION_DATABASE: {{ .Values.mariadb.mariadbDatabase | quote }}
+  PORTUS_PRODUCTION_DATABASE: {{ .Values.portus.productionDatabase | quote }}
+  PORTUS_PRODUCTION_USERNAME: {{ .Values.portus.productionUsername | quote }}
   PORTUS_KEY_PATH: "/certificates/portus.key"
   PORTUS_CERT_PATH: "/certificates/portus.crt"
   PORTUS_CHECK_SSL_USAGE_ENABLED: "true" 

--- a/contrib/helm-charts/Portus/templates/portus-deployment.yaml
+++ b/contrib/helm-charts/Portus/templates/portus-deployment.yaml
@@ -46,11 +46,6 @@ spec:
                 configMapKeyRef: 
                   name: "{{ .Release.Name }}-{{ .Values.portus.name }}"  
                   key: PORTUS_PRODUCTION_DATABASE
-            - name: PORTUS_PRODUCTION_USERNAME
-              valueFrom:
-                configMapKeyRef: 
-                  name: "{{ .Release.Name }}-{{ .Values.portus.name }}"  
-                  key: PORTUS_PRODUCTION_USERNAME
             - name: PORTUS_PRODUCTION_PASSWORD
               valueFrom:
                 secretKeyRef: 

--- a/contrib/helm-charts/Portus/templates/portus-deployment.yaml
+++ b/contrib/helm-charts/Portus/templates/portus-deployment.yaml
@@ -46,6 +46,11 @@ spec:
                 configMapKeyRef: 
                   name: "{{ .Release.Name }}-{{ .Values.portus.name }}"  
                   key: PORTUS_PRODUCTION_DATABASE
+            - name: PORTUS_PRODUCTION_USERNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: "{{ .Release.Name }}-{{ .Values.portus.name }}"
+                  key: PORTUS_PRODUCTION_USERNAME
             - name: PORTUS_PRODUCTION_PASSWORD
               valueFrom:
                 secretKeyRef: 

--- a/contrib/helm-charts/Portus/templates/portus-secret.yaml
+++ b/contrib/helm-charts/Portus/templates/portus-secret.yaml
@@ -10,7 +10,7 @@ metadata:
 type: Opaque
 data:
   PORTUS_PASSWORD: {{ .Values.portus.password | quote }}
-  PORTUS_PRODUCTION_PASSWORD: {{ .Values.mariadb.mariadbRootPassword | b64enc | quote }}
+  PORTUS_PRODUCTION_PASSWORD: {{ .Values.portus.productionPassword | quote }}
   PORTUS_SECRET_KEY_BASE: {{ .Values.portus.secretKeyBase | quote }}
 
   key: |

--- a/contrib/helm-charts/Portus/templates/portus-secret.yaml
+++ b/contrib/helm-charts/Portus/templates/portus-secret.yaml
@@ -10,7 +10,7 @@ metadata:
 type: Opaque
 data:
   PORTUS_PASSWORD: {{ .Values.portus.password | quote }}
-  PORTUS_PRODUCTION_PASSWORD: {{ .Values.portus.productionPassword | quote }} 
+  PORTUS_PRODUCTION_PASSWORD: {{ .Values.mariadb.mariadbRootPassword | b64enc | quote }}
   PORTUS_SECRET_KEY_BASE: {{ .Values.portus.secretKeyBase | quote }}
 
   key: |

--- a/contrib/helm-charts/Portus/values.yaml
+++ b/contrib/helm-charts/Portus/values.yaml
@@ -18,10 +18,16 @@ portus:
   fqdnValue: "portus-test.us.to" # TODO: this needs to be abstracted
   railsServeStaticFiles: true 
 
+  ## Database values
+  ##
+  productionHost:                    # name of database host, only used if connecting to separate mariadb deployment
+  productionDatabase: "portus"       # name of database
+  productionUsername: "root"         # database user
+  productionPassword: "cGFzc3dvcmQ=" # database password
+
   ## Secret values for Portus.
   ## 
   password: "cGFzc3dvcmQ="         
-  productionPassword: "cGFzc3dvcmQ="
   secretKeyBase:  "YjQ5NGEyNWZhYThkMjJlNDMwZTg0M2UyMjBlNDI0ZTEwYWM4NGQyY2UwZTY0MjMxZjViNjM2ZDIxMjUxZWI2ZDI2N2FkYjA0MmFkNTg4NGNiZmYwZjM4OTFiY2Y5MTFiZGY4YWJiM2NlNzE5ODQ5Y2NkYTlhNDg4OTI0OWU1YzI="
  
 ## Default values for Crono. 
@@ -70,16 +76,13 @@ mariadb:
   ##
   enabled: true
 
-  ## If using your own Mariadb deployment, provide the name of the service here
-  ##
-  # name:
-
   persistence:
     enabled: false
     accessMode: "ReadWriteOnce"
     size: "8Gi"
 
   ## Configuration values for Mariadb.
+  ## must match Portus database values.
   ##
   usePassword: true
   mariadbRootPassword: "password"

--- a/contrib/helm-charts/Portus/values.yaml
+++ b/contrib/helm-charts/Portus/values.yaml
@@ -16,9 +16,6 @@ portus:
   ## Configuration values for Portus.
   ## 
   fqdnValue: "portus-test.us.to" # TODO: this needs to be abstracted
-  productionHost: "mariadb"      # name of database host 
-  productionDatabase: "portus"   # name of database
-  productionUsername: "root"     # database user
   railsServeStaticFiles: true 
 
   ## Secret values for Portus.
@@ -68,8 +65,22 @@ nginx:
 ## Default values for Mariadb. 
 ##
 mariadb:
+  ## Use Mariadb chart dependency
+  ## Set to false if using your own Mariadb
+  ##
+  enabled: true
+
+  ## If using your own Mariadb deployment, provide the name of the service here
+  ##
+  # name:
+
   persistence:
     enabled: false
+    accessMode: "ReadWriteOnce"
+    size: "8Gi"
+
+  ## Configuration values for Mariadb.
+  ##
   usePassword: true
-  mariadbRootPassword: "password" 
+  mariadbRootPassword: "password"
   mariadbDatabase: "portus"


### PR DESCRIPTION
I removed the PORTUS_PRODUCTION_USERNAME value in the Portus and Crono deployments since the Portus app is configured to use the "root" db user by default :https://github.com/SUSE/Portus/blob/master/config/database.yml#L19

Plus the values file sets up a root Mariadb account by default, and I wanted all of the db configuration settings in the variables file to be in the "mariadb" section.

I'm wondering if we want to allow users to set a non "root" Mariadb account in the values file, because maybe somebody wants to incorporate an existing database they have, and they want to create a specific user for the Portus application to use?