### PR TITLE
Adds option to use ingress in Portus chart

### DIFF
--- a/contrib/helm-charts/Portus/templates/nginx-configmap.yaml
+++ b/contrib/helm-charts/Portus/templates/nginx-configmap.yaml
@@ -53,7 +53,7 @@ data:
       }
 
       server {
-        listen {{ .Values.nginx.port }} ssl http2;
+        listen {{ .Values.nginx.service.port }} ssl http2;
         server_name "{{ .Values.nginx.name }}"
         # root /srv/Portus/public;
 

--- a/contrib/helm-charts/Portus/templates/nginx-deployment.yaml
+++ b/contrib/helm-charts/Portus/templates/nginx-deployment.yaml
@@ -30,7 +30,7 @@ spec:
             - name: conf
               mountPath: /etc/nginx
           ports:
-            - containerPort: {{ .Values.nginx.port }} 
+            - containerPort: {{ .Values.nginx.service.port }}
       volumes:
         - name: certvol
           secret:

--- a/contrib/helm-charts/Portus/templates/nginx-ingress.yaml
+++ b/contrib/helm-charts/Portus/templates/nginx-ingress.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.nginx.ingress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: "{{ .Release.Name }}-{{ .Values.nginx.name }}"
+  labels:
+    app: {{ template "name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.nginx.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    - host: {{ .Values.nginx.fqdn | quote }}
+      http:
+        paths:
+          - backend:
+              serviceName: {{ .Values.nginx.name }} 
+              servicePort: {{ .Values.nginx.service.port }}
+  tls:
+    - secretName: {{ .Values.nginx.ingress.tls.secretName | quote }}
+      hosts:
+        - {{ .Values.nginx.fqdn | quote }}
+{{- end }}

--- a/contrib/helm-charts/Portus/templates/nginx-service.yaml
+++ b/contrib/helm-charts/Portus/templates/nginx-service.yaml
@@ -10,8 +10,10 @@ metadata:
 spec:
   selector:
     name: "{{ .Release.Name }}-{{ .Values.nginx.name }}"
-  type: NodePort
+  type: {{ .Values.nginx.service.type }}
   ports:
     - name: portus
-      port: {{ .Values.nginx.port }} 
-      nodePort: {{ .Values.nginx.externalPort }} 
+      port: {{ .Values.nginx.service.port }}
+  {{- if and (eq "NodePort" .Values.nginx.service.type) .Values.nginx.service.nodePort }}
+      nodePort: {{ .Values.nginx.service.nodePort }}
+  {{- end }}

--- a/contrib/helm-charts/Portus/templates/portus-configmap.yaml
+++ b/contrib/helm-charts/Portus/templates/portus-configmap.yaml
@@ -8,7 +8,8 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  PORTUS_MACHINE_FQDN_VALUE: {{ .Values.portus.fqdnValue | quote }}
+
+  PORTUS_MACHINE_FQDN_VALUE: {{ .Values.nginx.fqdn | quote }}
   {{- if .Values.mariadb.enabled }}
   PORTUS_PRODUCTION_HOST: "{{ .Release.Name }}-mariadb"
   {{- else }}
@@ -18,8 +19,8 @@ data:
   PORTUS_PRODUCTION_USERNAME: {{ .Values.portus.productionUsername | quote }}
   PORTUS_KEY_PATH: "/certificates/portus.key"
   PORTUS_CERT_PATH: "/certificates/portus.crt"
-  PORTUS_CHECK_SSL_USAGE_ENABLED: "true" 
-  RAILS_SERVE_STATIC_FILES: {{ .Values.portus.railsServeStaticFiles | quote }} 
+  PORTUS_CHECK_SSL_USAGE_ENABLED: "true"
+  RAILS_SERVE_STATIC_FILES: {{ .Values.portus.railsServeStaticFiles | quote }}
   CRONO_INIT_COMMAND: "bin/crono"
 
   config: |
@@ -27,13 +28,13 @@ data:
     # application. In order to change them, write your own config-local.yml file
     # (it will be ignored by git). For more info, you can read the dedicated page
     # here: http://port.us.org/docs/Configuring-Portus.html.
-    
+
     # Settings for the Portus mailer.
     email:
       from: "portus@example.com"
       name: "Portus"
       reply_to: "no-reply@example.com"
-    
+
       # If enabled, then SMTP will be used. Otherwise 'sendmail' will be used
       # (defaults to: /usr/sbin/sendmail -i -t).
       smtp:
@@ -43,12 +44,12 @@ data:
         user_name: "username@example.com"
         password: "password"
         domain: "example.com"
-    
+
     # If enabled, then the profile picture will be picked from the Gravatar
     # associated with each user. See: https://en.gravatar.com/
     gravatar:
       enabled: true
-    
+
     # Allow admins and owners to delete images and tags. This feature should *only*
     # be enabled if the version of the running registry is 2.4 or higher since
     # it's the first version that supports garbage collection. That being said,
@@ -61,35 +62,35 @@ data:
     # http://port.us.org/features/removing_images.html
     delete:
       enabled: false
-    
+
     # LDAP support. If enabled, then only users of the specified LDAP server will
     # be able to use Portus. Take a look at the documentation of LDAP support in our
     # online docs: http://port.us.org/features/2_LDAP-support.html.
     ldap:
       enabled: false
-    
+
       hostname: "ldap_hostname"
       port: 389
-    
+
       # Available options: "plain", "simple_tls" and "starttls". The default is
       # "plain", the recommended is "starttls".
       method: "plain"
-    
+
       # The base where users are located (e.g. "ou=users,dc=example,dc=com").
       base: ""
-    
+
       # User filter (e.g. "mail=george*").
       filter: ""
-    
+
       # The LDAP attribute where to search for username. The default is 'uid'.
       uid: "uid"
-    
+
       # LDAP credentials used to search for a user.
       authentication:
         enabled: false
         bind_dn: ""
         password: ""
-    
+
       # Portus needs an email for each user, but there's no standard way to get
       # that from LDAP servers. You can tell Portus how to get the email from users
       # registered in the LDAP server with this configurable value. There are three
@@ -111,7 +112,7 @@ data:
       guess_email:
         enabled: false
         attr: ""
-    
+
     # OAuth support.
     oauth:
       # If enabled, users can authenticate with their Google Account.
@@ -127,7 +128,7 @@ data:
           # G Suite domain. If set, then only members of the domain can sign in/up.
           # If it's empty then any google users con sign in/up.
           hd: ""
-    
+
       # OpenID authentication support. If enabled, then users can authenticate with OpenID/Connect
       # Callback url: <host>/users/auth/open_id/callback
       open_id:
@@ -138,7 +139,7 @@ data:
         identifier: ""
         # If a domain (e.g. mycompany.com) is set, then only signups with email from this domain are allowed.
         domain: ""
-    
+
       # Github authentication support.
       # Callback url: <host>/users/auth/github/callback
       github:
@@ -151,7 +152,7 @@ data:
         team: ""
          # If a domain (e.g. mycompany.com) is set, then only signups with email from this domain are allowed.
         domain: ""
-    
+
       # Gitlab authentication support.
       # Callback url: <host>/users/auth/gitlab/callback
       gitlab:
@@ -164,7 +165,7 @@ data:
         domain: ""
         # The Gitlab server to be used. If empty, then https://gitlab.com is assumed.
         server: ""
-    
+
       # Bitbucket authentication support. Need permission to read email.
       # Callback url: <host>/users/auth/bitbucket/callback
       bitbucket:
@@ -177,7 +178,7 @@ data:
         options:
           # Only members of team can sign in/up with Bitbucket. Need permission to read team membership.
           team: ""
-    
+
     # Set first_user_admin to true if you want that the first user that signs up
     # to be an admin.
     #
@@ -186,7 +187,7 @@ data:
     # in order to set the admin user
     first_user_admin:
       enabled: true
-    
+
     # If enabled, then users can signup with the signup form. Otherwise, the admin
     # is responsible of creating new users by either:
     #   - Using the "portus:create_user" rake task.
@@ -195,11 +196,11 @@ data:
     # http://port.us.org/features/disabling_signup.html
     signup:
       enabled: true
-    
+
     # By default require ssl to be enabled when running on production
     check_ssl_usage:
-      enabled: true 
-    
+      enabled: true
+
     # Contains advanced options that tweak how Portus interacts with the
     # Registry. Don't touch any of these values unless you *really* know what you
     # are doing.
@@ -214,56 +215,56 @@ data:
       # See: https://github.com/SUSE/Portus/issues/510
       jwt_expiration_time:
         value: 5
-    
+
       # Set the pagination value for API calls that fetch data from the
       # registry. You can read more about pagination in the registry here:
       #   https://github.com/docker/distribution/blob/master/docs/spec/api.md#pagination
       catalog_page:
         value: 100
-    
+
       # Set the timeout in seconds for requests to the registry. Only change this
       # value if you are *really* sure that you have an exceptionally slow
       # connection to your private Docker registry.
       timeout:
         value: 2
-    
+
     # The FQDN of the machine where Portus is being deployed.
     machine_fqdn:
       value: "{{ .Values.portus.name }}"
-    
+
     # Allow users to have different display names on the web site. This will
     # **not** be the username used by `docker login`. It defaults to false because
     # it might confuse users that are not fully aware of it. You can read more about
     # it here: http://port.us.org/features/display_name.html
     display_name:
       enabled: false
-    
+
     user_permission:
       # Allow users to change the visibility or their personal namespace. If this is
       # disabled, only an admin will be able to change this. It defaults to true.
       change_visibility:
         enabled: true
-    
+
       # Allow users to create teams. If this is disabled only an admin will be able
       # to do this. This defaults to true.
       create_team:
         enabled: true
-    
+
       # Allow users to create/modify teams if they are an owner of it. If this is
       # disabled only an admin will be able to do this. This defaults to true.
       manage_team:
         enabled: true
-    
+
       # Allow users to create namespaces. If this is disabled, only an admin will
       # be able to do this. This defaults to true.
       create_namespace:
         enabled: true
-    
+
       # Allow users to create/modify namespaces if they are an owner of it. If this
       # is disabled, only an admin will be able to do this. This defaults to true.
       manage_namespace:
         enabled: true
-    
+
     # Security scanner support. Add the server location for each driver in order to
     # enable it. If no drivers have been enabled, then this feature is skipped
     # altogether. Enabling multiple drivers will simply aggregate the information
@@ -272,11 +273,11 @@ data:
       # CoreOS Clair support (https://github.com/coreos/clair).
       clair:
         server: "http://clair:6060"
-    
+
         # Port being used by Clair to report its status. Taking the default from
         # Clair.
         health_port: 6061
-    
+
       # zypper-docker can be run as a server with its `serve` command. This backend
       # fetches the information as given by zypper-docker. Note that this feature
       # from zypper-docker is experimental and only available through another branch
@@ -286,11 +287,11 @@ data:
       # been merged into master yet in zypper-docker.
       zypper:
         server: ""
-    
+
       # This backend is only used for testing purposes, don't use it.
       dummy:
         server: ""
-    
+
     # Allow anonymous (non-logged-in) users to explore the images available in your
     # Docker Registry. Only images on public namespaces will be shown.
     anonymous_browsing:

--- a/contrib/helm-charts/Portus/templates/registry-configmap.yaml
+++ b/contrib/helm-charts/Portus/templates/registry-configmap.yaml
@@ -8,7 +8,13 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  REGISTRY_AUTH_TOKEN_REALM: "https://{{ .Values.portus.fqdnValue }}:{{ .Values.nginx.externalPort }}/v2/token"
+  {{- if .Values.nginx.ingress.enabled }}
+  REGISTRY_AUTH_TOKEN_REALM: "https://{{ .Values.nginx.fqdn }}:{{ .Values.nginx.ingress.port }}/v2/token"
+  {{- else if and (eq "NodePort" .Values.nginx.service.type) .Values.nginx.service.nodePort }}
+  REGISTRY_AUTH_TOKEN_REALM: "https://{{ .Values.nginx.fqdn }}:{{ .Values.nginx.service.nodePort }}/v2/token"
+  {{- else }}
+  REGISTRY_AUTH_TOKEN_REALM: "https://{{ .Values.nginx.fqdn }}:{{ .Values.ningx.service.port }}/v2/token"
+  {{- end }}
   REGISTRY_AUTH_TOKEN_SERVICE: "{{ .Values.registry.name }}:{{ .Values.registry.port }}"
   REGISTRY_AUTH_TOKEN_ISSUER: {{ .Values.portus.name | quote }} 
   REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE: "/certificates/portus.crt"

--- a/contrib/helm-charts/Portus/values.yaml
+++ b/contrib/helm-charts/Portus/values.yaml
@@ -9,14 +9,13 @@ portus:
   image:
     repository: "opensuse/portus"
     tag: "head"
-    pullPolicy: "IfNotPresent" 
+    pullPolicy: "IfNotPresent"
   replicas: 1
   port: 3000
-  
+
   ## Configuration values for Portus.
-  ## 
-  fqdnValue: "portus-test.us.to" # TODO: this needs to be abstracted
-  railsServeStaticFiles: true 
+  ##
+  railsServeStaticFiles: true
 
   ## Database values
   ##
@@ -26,11 +25,11 @@ portus:
   productionPassword: "cGFzc3dvcmQ=" # database password
 
   ## Secret values for Portus.
-  ## 
-  password: "cGFzc3dvcmQ="         
+  ##
+  password: "cGFzc3dvcmQ="
   secretKeyBase:  "YjQ5NGEyNWZhYThkMjJlNDMwZTg0M2UyMjBlNDI0ZTEwYWM4NGQyY2UwZTY0MjMxZjViNjM2ZDIxMjUxZWI2ZDI2N2FkYjA0MmFkNTg4NGNiZmYwZjM4OTFiY2Y5MTFiZGY4YWJiM2NlNzE5ODQ5Y2NkYTlhNDg4OTI0OWU1YzI="
- 
-## Default values for Crono. 
+
+## Default values for Crono.
 ##
 crono:
   name: "crono"
@@ -40,7 +39,7 @@ crono:
     pullPolicy: "IfNotPresent"
   replicas: 1
 
-## Default values for Docker Registry. 
+## Default values for Docker Registry.
 ##
 registry:
   name: "registry"
@@ -49,26 +48,55 @@ registry:
     enabled: true
     accessMode: "ReadWriteOnce"
     capacity: "10Gi"
-  image: 
+  image:
     repository: "library/registry"
-    tag: "latest" 
+    tag: "latest"
     pullPolicy: "IfNotPresent"
   replicas: 1
   port: "5000"
   debugPort: "5001"
 
-## Default values for Nginx. 
+## Default values for Nginx.
 ##
 nginx:
   name: "nginx"
-  image: 
+  image:
     repository: "library/nginx"
     tag: "alpine"
     pullPolicy: "IfNotPresent"
-  port: "443"
-  externalPort: "32123"
 
-## Default values for Mariadb. 
+  ## Domain name for entry point
+  ##
+  fqdn: "portus-test.us.to"
+
+  ## Service configuration.
+  ##
+  service:
+    ## If using Ingress use type ClusterIP, else use NodePort
+    ##
+    type: "NodePort"
+    port: "443"
+    nodePort: "32123"
+
+  ingress:
+    enabled: false
+
+    ## Anntations to be added to the web ingress
+    ##
+    annotations:
+      kubernetes.io/ingress.class: "nginx"
+      kubernetes.io/ingress.allow-http: "false"
+      ingress.kubernetes.io/ssl-passthrough: "true"
+
+    port: "32123"
+
+    ## TLS configuration
+    ## Secrets must be manually created in the namespace
+    ##
+    tls:
+      secretName: "portus-tls"
+
+## Default values for Mariadb.
 ##
 mariadb:
   ## Use Mariadb chart dependency


### PR DESCRIPTION
These changes allow people to install the chart with an ingress entry point, instead of a node port. `.Values.nginx.ingress.enabled` must be set to true to use ingress. 

By default ingress is turned off, because that seems to be the setting that charts with ingress resources have by default in the stable repo.

This chart still works with a node port, if ingress is not enabled.