### PR TITLE
Make OAuth and OpenID Connect configurable

### DIFF
--- a/contrib/helm-charts/portus/templates/portus-configmap.yaml
+++ b/contrib/helm-charts/portus/templates/portus-configmap.yaml
@@ -101,6 +101,11 @@ data:
     # OAuth support.
     {{- if .Values.portus.config.oauth }}{{ with .Values.portus.config.oauth }}
     oauth:
+      # If enabled, then users can login with portus credential.
+      # Otherwise, the users can only login via OAuth.
+      local_login:
+{{ toYaml .local_login | indent 8 }}
+
       # If enabled, users can authenticate with their Google Account.
       # Callback url: <host>/users/auth/google_oauth2/callback
       google_oauth2:

--- a/contrib/helm-charts/portus/templates/portus-configmap.yaml
+++ b/contrib/helm-charts/portus/templates/portus-configmap.yaml
@@ -101,11 +101,6 @@ data:
     # OAuth support.
     {{- if .Values.portus.config.oauth }}{{ with .Values.portus.config.oauth }}
     oauth:
-      # If enabled, then users can login with portus credential.
-      # Otherwise, the users can only login via OAuth.
-      local_login:
-{{ toYaml .local_login | indent 8 }}
-
       # If enabled, users can authenticate with their Google Account.
       # Callback url: <host>/users/auth/google_oauth2/callback
       google_oauth2:

--- a/contrib/helm-charts/portus/templates/portus-configmap.yaml
+++ b/contrib/helm-charts/portus/templates/portus-configmap.yaml
@@ -104,70 +104,26 @@ data:
       # If enabled, users can authenticate with their Google Account.
       # Callback url: <host>/users/auth/google_oauth2/callback
       google_oauth2:
-        # enabled: false
-        # # Credentials. Details on https://developers.google.com/identity/protocols/OpenIDConnect
-        # id: ""
-        # secret: ""
-        # # If a domain (e.g. mycompany.com) is set, then only signups with email from this domain are allowed.
-        # domain: ""
-        # options:
-        #   # G Suite domain. If set, then only members of the domain can sign in/up.
-        #   # If it's empty then any google users con sign in/up.
-        #   hd: ""
 {{ toYaml .google_oauth2 | indent 8 }}
 
       # OpenID authentication support. If enabled, then users can authenticate with OpenID/Connect
       # Callback url: <host>/users/auth/open_id/callback
       open_id:
-        # enabled: false
-        # # Optional. If identifier set then user redirect to the OpenID provider.
-        # # If not, then user is asked for identifier before redirect.
-        # # Example https://openid.stackexchange.com
-        # identifier: ""
-        # # If a domain (e.g. mycompany.com) is set, then only signups with email from this domain are allowed.
-        # domain: ""
 {{ toYaml .open_id | indent 8 }}
 
       # Github authentication support.
       # Callback url: <host>/users/auth/github/callback
       github:
-        # enabled: false
-        # # Application credentials.
-        # client_id: ""
-        # client_secret: ""
-        # # Only members of organization's team can sign in/up with Github.
-        # organization: ""
-        # team: ""
-        # # If a domain (e.g. mycompany.com) is set, then only signups with email from this domain are allowed.
-        # domain: ""
 {{ toYaml .github | indent 8 }}
 
       # Gitlab authentication support.
       # Callback url: <host>/users/auth/gitlab/callback
       gitlab:
-        # enabled: false
-        # application_id: ""
-        # secret: ""
-        # # Only member of the group can sign in/up with Gitlab.
-        # group: ""
-        # # If a domain (e.g. mycompany.com) is set, then only signups with email from this domain are allowed.
-        # domain: ""
-        # # The Gitlab server to be used. If empty, then https://gitlab.com is assumed.
-        # server: ""
 {{ toYaml .gitlab | indent 8 }}
 
       # Bitbucket authentication support. Need permission to read email.
       # Callback url: <host>/users/auth/bitbucket/callback
       bitbucket:
-        # enabled: false
-        # # Application credentials.
-        # key: ""
-        # secret: ""
-        # # If a domain (e.g. mycompany.com) is set, then only signups with email from this domain are allowed.
-        # domain: ""
-        # options:
-        #   # Only members of team can sign in/up with Bitbucket. Need permission to read team membership.
-        #   team: ""
 {{ toYaml .bitbucket | indent 8 }}
     {{- end }}{{ end }}
 

--- a/contrib/helm-charts/portus/templates/portus-configmap.yaml
+++ b/contrib/helm-charts/portus/templates/portus-configmap.yaml
@@ -99,70 +99,77 @@ data:
         attr: ""
 
     # OAuth support.
+    {{- if .Values.portus.config.oauth }}{{ with .Values.portus.config.oauth }}
     oauth:
       # If enabled, users can authenticate with their Google Account.
       # Callback url: <host>/users/auth/google_oauth2/callback
       google_oauth2:
-        enabled: false
-        # Credentials. Details on https://developers.google.com/identity/protocols/OpenIDConnect
-        id: ""
-        secret: ""
-        # If a domain (e.g. mycompany.com) is set, then only signups with email from this domain are allowed.
-        domain: ""
-        options:
-          # G Suite domain. If set, then only members of the domain can sign in/up.
-          # If it's empty then any google users con sign in/up.
-          hd: ""
+        # enabled: false
+        # # Credentials. Details on https://developers.google.com/identity/protocols/OpenIDConnect
+        # id: ""
+        # secret: ""
+        # # If a domain (e.g. mycompany.com) is set, then only signups with email from this domain are allowed.
+        # domain: ""
+        # options:
+        #   # G Suite domain. If set, then only members of the domain can sign in/up.
+        #   # If it's empty then any google users con sign in/up.
+        #   hd: ""
+{{ toYaml .google_oauth2 | indent 8 }}
 
       # OpenID authentication support. If enabled, then users can authenticate with OpenID/Connect
       # Callback url: <host>/users/auth/open_id/callback
       open_id:
-        enabled: false
-        # Optional. If identifier set then user redirect to the OpenID provider.
-        # If not, then user is asked for identifier before redirect.
-        # Example https://openid.stackexchange.com
-        identifier: ""
-        # If a domain (e.g. mycompany.com) is set, then only signups with email from this domain are allowed.
-        domain: ""
+        # enabled: false
+        # # Optional. If identifier set then user redirect to the OpenID provider.
+        # # If not, then user is asked for identifier before redirect.
+        # # Example https://openid.stackexchange.com
+        # identifier: ""
+        # # If a domain (e.g. mycompany.com) is set, then only signups with email from this domain are allowed.
+        # domain: ""
+{{ toYaml .open_id | indent 8 }}
 
       # Github authentication support.
       # Callback url: <host>/users/auth/github/callback
       github:
-        enabled: false
-        # Application credentials.
-        client_id: ""
-        client_secret: ""
-        # Only members of organization's team can sign in/up with Github.
-        organization: ""
-        team: ""
-        # If a domain (e.g. mycompany.com) is set, then only signups with email from this domain are allowed.
-        domain: ""
+        # enabled: false
+        # # Application credentials.
+        # client_id: ""
+        # client_secret: ""
+        # # Only members of organization's team can sign in/up with Github.
+        # organization: ""
+        # team: ""
+        # # If a domain (e.g. mycompany.com) is set, then only signups with email from this domain are allowed.
+        # domain: ""
+{{ toYaml .github | indent 8 }}
 
       # Gitlab authentication support.
       # Callback url: <host>/users/auth/gitlab/callback
       gitlab:
-        enabled: false
-        application_id: ""
-        secret: ""
-        # Only member of the group can sign in/up with Gitlab.
-        group: ""
-        # If a domain (e.g. mycompany.com) is set, then only signups with email from this domain are allowed.
-        domain: ""
-        # The Gitlab server to be used. If empty, then https://gitlab.com is assumed.
-        server: ""
+        # enabled: false
+        # application_id: ""
+        # secret: ""
+        # # Only member of the group can sign in/up with Gitlab.
+        # group: ""
+        # # If a domain (e.g. mycompany.com) is set, then only signups with email from this domain are allowed.
+        # domain: ""
+        # # The Gitlab server to be used. If empty, then https://gitlab.com is assumed.
+        # server: ""
+{{ toYaml .gitlab | indent 8 }}
 
       # Bitbucket authentication support. Need permission to read email.
       # Callback url: <host>/users/auth/bitbucket/callback
       bitbucket:
-        enabled: false
-        # Application credentials.
-        key: ""
-        secret: ""
-        # If a domain (e.g. mycompany.com) is set, then only signups with email from this domain are allowed.
-        domain: ""
-        options:
-          # Only members of team can sign in/up with Bitbucket. Need permission to read team membership.
-          team: ""
+        # enabled: false
+        # # Application credentials.
+        # key: ""
+        # secret: ""
+        # # If a domain (e.g. mycompany.com) is set, then only signups with email from this domain are allowed.
+        # domain: ""
+        # options:
+        #   # Only members of team can sign in/up with Bitbucket. Need permission to read team membership.
+        #   team: ""
+{{ toYaml .bitbucket | indent 8 }}
+    {{- end }}{{ end }}
 
     # Set first_user_admin to true if you want that the first user that signs up
     # to be an admin.

--- a/contrib/helm-charts/portus/values.yaml
+++ b/contrib/helm-charts/portus/values.yaml
@@ -58,6 +58,27 @@ portus:
         domain: "example.com"
     gravatar: true  # If enabled, then the profile picture will be picked from the Gravatar
     delete: true  # Allow admins and owners to delete images and tags
+    oauth:
+      # If enabled, users can authenticate with their Google Account.
+      # Callback url: <host>/users/auth/google_oauth2/callback
+      google_oauth2:
+        enabled: false
+      # OpenID authentication support. If enabled, then users can authenticate with OpenID/Connect
+      # Callback url: <host>/users/auth/open_id/callback
+      open_id:
+        enabled: false
+      # Github authentication support.
+      # Callback url: <host>/users/auth/github/callback
+      github:
+        enabled: false
+      # Gitlab authentication support.
+      # Callback url: <host>/users/auth/gitlab/callback
+      gitlab:
+        enabled: false
+      # Bitbucket authentication support. Need permission to read email.
+      # Callback url: <host>/users/auth/bitbucket/callback
+      bitbucket:
+        enabled: false
     first_user_admin: true # First user signing up will be admin
     signup: true  # If enabled, then users can signup with the signup form
     display_name: false  # Allow users to have different display names on the web site

--- a/contrib/helm-charts/portus/values.yaml
+++ b/contrib/helm-charts/portus/values.yaml
@@ -59,10 +59,6 @@ portus:
     gravatar: true  # If enabled, then the profile picture will be picked from the Gravatar
     delete: true  # Allow admins and owners to delete images and tags
     oauth:
-      # If enabled, then users can login with portus credential.
-      # Otherwise, the users can only login via OAuth.
-      local_login:
-        enabled: true
       # If enabled, users can authenticate with their Google Account.
       # Callback url: <host>/users/auth/google_oauth2/callback
       google_oauth2:
@@ -171,7 +167,7 @@ nginx:
   ## Service configuration.
   ##
   service:
-    ## Set to ClusterIP if using ingress, or NodePort if using minikube 
+    ## Set to ClusterIP if using ingress, or NodePort if using minikube
     ##
     type: "ClusterIP"
 

--- a/contrib/helm-charts/portus/values.yaml
+++ b/contrib/helm-charts/portus/values.yaml
@@ -59,6 +59,10 @@ portus:
     gravatar: true  # If enabled, then the profile picture will be picked from the Gravatar
     delete: true  # Allow admins and owners to delete images and tags
     oauth:
+      # If enabled, then users can login with portus credential.
+      # Otherwise, the users can only login via OAuth.
+      local_login:
+        enabled: true
       # If enabled, users can authenticate with their Google Account.
       # Callback url: <host>/users/auth/google_oauth2/callback
       google_oauth2:


### PR DESCRIPTION
Make it possible to set the OAuth field in Portus configuration file from externally.