### PR TITLE
Fix liveness probe

### DIFF
--- a/contrib/helm-charts/portus/Chart.yaml
+++ b/contrib/helm-charts/portus/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 home: http://port.us.org
-description: A Portus Helm chart for Kubernetes. Portus is an authorization and user interface for the next generation of the Docker registry. 
+description: A Portus Helm chart for Kubernetes. Portus is an authorization and user interface for the next generation of the Docker registry.
 name: portus
-version: 0.1.0
+version: 0.1.1
 sources:
   - https://github.com/kubic-project/caasp-services/tree/master/contrib/helm-charts/Portus
 maintainers:

--- a/contrib/helm-charts/portus/templates/portus-deployment.yaml
+++ b/contrib/helm-charts/portus/templates/portus-deployment.yaml
@@ -36,7 +36,7 @@ spec:
               {{- end }}
               path: /api/v1/_ping
               port: {{ .Values.portus.service.port }}
-            initialDelaySeconds: 60
+            initialDelaySeconds: 240
             timeoutSeconds: 10
           env:
             - name: PORTUS_MACHINE_FQDN_VALUE

--- a/contrib/helm-charts/portus/templates/portus-deployment.yaml
+++ b/contrib/helm-charts/portus/templates/portus-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "portus.fullname" . }} 
+  name: {{ template "portus.fullname" . }}
   labels:
     name: {{ template "portus.fullname" . }}
     app: {{ template "name" . }}
@@ -30,11 +30,14 @@ spec:
           ports:
             - containerPort: {{ .Values.portus.service.port }}
           livenessProbe:
-            exec:
-              command:
-                - /api/v1/health
-            initialDelaySeconds: 240
-            periodSeconds: 5
+            httpGet:
+              {{- if .Values.portus.tls.enabled }}
+              scheme: HTTPS
+              {{- end }}
+              path: /api/v1/health
+              port: {{ .Values.portus.service.port }}
+            initialDelaySeconds: 300
+            timeoutSeconds: 10
           env:
             - name: PORTUS_MACHINE_FQDN_VALUE
               value: {{ template "portus.fullname" . }}
@@ -62,7 +65,7 @@ spec:
             - name: PORTUS_DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "portus.fullname" . }}  
+                  name: {{ template "portus.fullname" . }}
                   key: PORTUS_PRODUCTION_PASSWORD
             {{- end }}
             - name: PORTUS_KEY_PATH

--- a/contrib/helm-charts/portus/templates/portus-deployment.yaml
+++ b/contrib/helm-charts/portus/templates/portus-deployment.yaml
@@ -34,9 +34,9 @@ spec:
               {{- if .Values.portus.tls.enabled }}
               scheme: HTTPS
               {{- end }}
-              path: /api/v1/health
+              path: /api/v1/_ping
               port: {{ .Values.portus.service.port }}
-            initialDelaySeconds: 300
+            initialDelaySeconds: 60
             timeoutSeconds: 10
           env:
             - name: PORTUS_MACHINE_FQDN_VALUE


### PR DESCRIPTION
Currently, This chart uses command to health checking, but it is not valid.
Therefore, every time a health check is performed, the container restarts.
I think that health checking should use http(s) request.