### PR TITLE
Add oauth provider

### DIFF
--- a/contrib/helm-charts/portus/Chart.yaml
+++ b/contrib/helm-charts/portus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 home: http://port.us.org
 description: A Portus Helm chart for Kubernetes. Portus is an authorization and user interface for the next generation of the Docker registry.
 name: portus
-version: 0.1.2
+version: 0.1.3
 sources:
   - https://github.com/kubic-project/caasp-services/tree/master/contrib/helm-charts/Portus
 maintainers:

--- a/contrib/helm-charts/portus/templates/portus-configmap.yaml
+++ b/contrib/helm-charts/portus/templates/portus-configmap.yaml
@@ -104,40 +104,40 @@ data:
       # If enabled, users can authenticate with their Google Account.
       # Callback url: <host>/users/auth/google_oauth2/callback
       google_oauth2:
-        enabled: false
+        enabled: {{ .Values.portus.config.oauth.google_oauth2.enabled }}
         # Credentials. Details on https://developers.google.com/identity/protocols/OpenIDConnect
-        id: ""
-        secret: ""
+        id: {{ .Values.portus.config.oauth.google_oauth2.id | quote }}
+        secret: {{ .Values.portus.config.oauth.google_oauth2.secret | quote }}
         # If a domain (e.g. mycompany.com) is set, then only signups with email from this domain are allowed.
-        domain: ""
+        domain: {{ .Values.portus.config.oauth.google_oauth2.domain | quote }}
         options:
           # G Suite domain. If set, then only members of the domain can sign in/up.
           # If it's empty then any google users con sign in/up.
-          hd: ""
+          hd: {{ .Values.portus.config.oauth.google_oauth2.options.hd | quote }}
 
       # OpenID authentication support. If enabled, then users can authenticate with OpenID/Connect
       # Callback url: <host>/users/auth/open_id/callback
       open_id:
-        enabled: false
+        enabled: {{ .Values.portus.config.oauth.open_id.enabled }}
         # Optional. If identifier set then user redirect to the OpenID provider.
         # If not, then user is asked for identifier before redirect.
         # Example https://openid.stackexchange.com
-        identifier: ""
+        identifier: {{ .Values.portus.config.oauth.open_id.identifier | quote }}
         # If a domain (e.g. mycompany.com) is set, then only signups with email from this domain are allowed.
-        domain: ""
+        domain: {{ .Values.portus.config.oauth.open_id.domain | quote }}
 
       # Github authentication support.
       # Callback url: <host>/users/auth/github/callback
       github:
-        enabled: false
+        enabled: {{ .Values.portus.config.oauth.github.enabled }}
         # Application credentials.
-        client_id: ""
-        client_secret: ""
+        client_id: {{ .Values.portus.config.oauth.github.client_id | quote }}
+        client_secret: {{ .Values.portus.config.oauth.github.client_secret | quote }}
         # Only members of organization's team can sign in/up with Github.
-        organization: ""
-        team: ""
+        organization: {{ .Values.portus.config.oauth.github.organization | quote }}
+        team: {{ .Values.portus.config.oauth.github.team | quote }}
         # If a domain (e.g. mycompany.com) is set, then only signups with email from this domain are allowed.
-        domain: ""
+        domain: {{ .Values.portus.config.oauth.github.domain | quote }}
 
       # Gitlab authentication support.
       # Callback url: <host>/users/auth/gitlab/callback
@@ -155,15 +155,15 @@ data:
       # Bitbucket authentication support. Need permission to read email.
       # Callback url: <host>/users/auth/bitbucket/callback
       bitbucket:
-        enabled: false
+        enabled: {{ .Values.portus.config.oauth.enabled }}
         # Application credentials.
-        key: ""
-        secret: ""
+        key: {{ .Values.portus.config.oauth.key | quote }}
+        secret: {{ .Values.portus.config.oauth.secret | quote }}
         # If a domain (e.g. mycompany.com) is set, then only signups with email from this domain are allowed.
-        domain: ""
+        domain: {{ .Values.portus.config.oauth.domain | quote }}
         options:
           # Only members of team can sign in/up with Bitbucket. Need permission to read team membership.
-          team: ""
+          team: {{ .Values.portus.config.oauth.options.team | quote }}
 
     # Set first_user_admin to true if you want that the first user that signs up
     # to be an admin.

--- a/contrib/helm-charts/portus/templates/portus-configmap.yaml
+++ b/contrib/helm-charts/portus/templates/portus-configmap.yaml
@@ -143,7 +143,7 @@ data:
       # Callback url: <host>/users/auth/gitlab/callback
       gitlab:
         enabled: {{ .Values.portus.config.oauth.gitlab.enabled }}
-        application_id: {{ .Values.portus.config.oauth.gitlab.applicationId | quote }}
+        application_id: {{ .Values.portus.config.oauth.gitlab.application_id | quote }}
         secret: {{ .Values.portus.config.oauth.gitlab.secret | quote }}
         # Only member of the group can sign in/up with Gitlab.
         group: {{ .Values.portus.config.oauth.gitlab.group | quote }}

--- a/contrib/helm-charts/portus/values.yaml
+++ b/contrib/helm-charts/portus/values.yaml
@@ -126,6 +126,33 @@ portus:
       manage_namespace: true  # Allow users to create/modify namespaces if they are an owner of it
 
     oauth:
+      # If enabled, users can authenticate with their Google Account.
+      # Callback url: <host>/users/auth/google_oauth2/callback
+      google_oauth2:
+        enabled: false
+        id:
+        secret:
+        domain:
+        options:
+          hd:
+
+      # OpenID authentication support. If enabled, then users can authenticate with OpenID/Connect
+      # Callback url: <host>/users/auth/open_id/callback
+      open_id:
+        enabled: false
+        identifier:
+        domain:
+
+      # Github authentication support.
+      # Callback url: <host>/users/auth/github/callback
+      github:
+        enabled: false
+        client_id:
+        client_secret:
+        organization:
+        team:
+        domain:
+
       # Gitlab authentication support.
       # Callback url: <host>/users/auth/gitlab/callback
       gitlab:
@@ -135,6 +162,16 @@ portus:
         group:
         domain:
         server:
+
+      # Bitbucket authentication support. Need permission to read email.
+      # Callback url: <host>/users/auth/bitbucket/callback
+      bitbucket:
+        enabled: false
+        key:
+        secret:
+        domain:
+        options:
+          team:
 
     security:
       clair:

--- a/contrib/helm-charts/portus/values.yaml
+++ b/contrib/helm-charts/portus/values.yaml
@@ -157,7 +157,7 @@ portus:
       # Callback url: <host>/users/auth/gitlab/callback
       gitlab:
         enabled: false
-        applicationId:
+        application_id:
         secret:
         group:
         domain:


### PR DESCRIPTION
Currently, The OAuth Provider we can configure is only GitHub.
Make the following providers configurable:
- Google
- OpenID Provider
- GitHub
- BitBucket

In addition, it wrote by different ways from the previous pull request.
https://github.com/kubic-project/caasp-services/pull/32