### PR TITLE
Fix Bitbucket values

### DIFF
--- a/contrib/helm-charts/portus/Chart.yaml
+++ b/contrib/helm-charts/portus/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 home: http://port.us.org
 description: A Portus Helm chart for Kubernetes. Portus is an authorization and user interface for the next generation of the Docker registry.
 name: portus
-version: 0.1.3
+version: 0.1.4
 sources:
   - https://github.com/kubic-project/caasp-services/tree/master/contrib/helm-charts/Portus
 maintainers:
-  - name: John Bonham
-    email: jbonham@suse.com
+  - name: SUSE Containers Team
+    email: containers@suse.com

--- a/contrib/helm-charts/portus/templates/portus-configmap.yaml
+++ b/contrib/helm-charts/portus/templates/portus-configmap.yaml
@@ -155,15 +155,15 @@ data:
       # Bitbucket authentication support. Need permission to read email.
       # Callback url: <host>/users/auth/bitbucket/callback
       bitbucket:
-        enabled: {{ .Values.portus.config.oauth.enabled }}
+        enabled: {{ .Values.portus.config.oauth.bitbucket.enabled }}
         # Application credentials.
-        key: {{ .Values.portus.config.oauth.key | quote }}
-        secret: {{ .Values.portus.config.oauth.secret | quote }}
+        key: {{ .Values.portus.config.oauth.bitbucket.key | quote }}
+        secret: {{ .Values.portus.config.oauth.bitbucket.secret | quote }}
         # If a domain (e.g. mycompany.com) is set, then only signups with email from this domain are allowed.
-        domain: {{ .Values.portus.config.oauth.domain | quote }}
+        domain: {{ .Values.portus.config.oauth.bitbucket.domain | quote }}
         options:
           # Only members of team can sign in/up with Bitbucket. Need permission to read team membership.
-          team: {{ .Values.portus.config.oauth.options.team | quote }}
+          team: {{ .Values.portus.config.oauth.bitbucket.options.team | quote }}
 
     # Set first_user_admin to true if you want that the first user that signs up
     # to be an admin.


### PR DESCRIPTION
Fix bitbucket oauth value references in the Portus ConfigMap. 
Chart maintainer is now set to containers team. 